### PR TITLE
Big Sur Fix

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/issue-template.md
+++ b/.github/ISSUE_TEMPLATE/issue-template.md
@@ -12,7 +12,7 @@ Please fill in the template below to speed up the review process:
 **Mac model:**
 **iPad model:**
 
-**Mac version** (optional):
-**iPad version** (optional):
+**Mac version**:
+**iPad version**:
 
 **Comments:**

--- a/README.md
+++ b/README.md
@@ -66,13 +66,13 @@ sudo cp ~/Downloads/SidecarCore /System/Library/PrivateFrameworks/SidecarCore.fr
 8. Sign the patched SidecarCore (in Terminal):
     * If you see an error in this step, make sure you have xcode command-line tools installed (`xcode-select --install`, see [#3]) or updated (through App Store, see [#2]).
     * Don't restart your computer until you complete this step properly (or revert the backup file)! Many people have run into issues with this ([#28], [#22]).
-    * **macOS Catalina 10.15.4+ users: [Add `amfi_get_out_of_my_way=0x1` to NVRAM boot flags](https://github.com/ben-z/free-sidecar/issues/59#issuecomment-603953953), then skip step 9.**
+    * **macOS Catalina 10.15.4+ users:** Run [`sudo nvram boot-args="amfi_get_out_of_my_way=0x1"`](https://github.com/ben-z/free-sidecar/issues/59#issuecomment-603953953), **then skip step 9.**
 
 ```
 sudo codesign -f -s - /System/Library/PrivateFrameworks/SidecarCore.framework/Versions/A/SidecarCore
 ```
 
-9. (Optional, but recommended **(but [not recommended][#59] for macOS Catalina 10.15.4)**) Reboot Into Recovery, re-enable System Integrity Protection:
+9. (Optional, but recommended **(but [not recommended][#59] for macOS Catalina 10.15.4+)**) Reboot Into Recovery, re-enable System Integrity Protection:
 
 ```
 csrutil enable
@@ -88,7 +88,7 @@ csrutil enable
      
 1. "Error 32002"
 
-    This happens on wireless connection for some models. Try using a wire instead. (Some people have reported that wired isn't working either on some older models e.g. [MacbookPro 2012](https://www.reddit.com/r/MacOSBeta/comments/dnxxc7/psa_enable_sidecar_on_older_devices_works_for/f5l64ni?utm_source=share&utm_medium=web2x))
+    This happens on wireless connection for some models. Try using a wire instead and confirm your device appears listed on Finder and it's trusted. If it does not appear, try a different lightning cable (Some people have reported that wired isn't working either on some older models e.g. [MacbookPro 2012](https://www.reddit.com/r/MacOSBeta/comments/dnxxc7/psa_enable_sidecar_on_older_devices_works_for/f5l64ni?utm_source=share&utm_medium=web2x))
     
 1. "None of my apps open anymore, They keep crashing!"
     
@@ -120,7 +120,10 @@ csrutil enable
     sudo cp ~/Downloads/SidecarCore.bak /System/Library/PrivateFrameworks/SidecarCore.framework/Versions/A/SidecarCore
     ```
     
-    Then re-enable System Integrity Protection (step 9). Your system should be in the same state as before you applied the patch!
+    * macOS 10.15.4+: Run `sudo nvram -d boot-args`
+    * Earlier macOS 10.15 versions: re-enable System Integrity Protection (step 9).
+
+    Your system should be in the same state as before you applied the patch!
 
 ### Contributing
 

--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 # Free Sidecar 
 
 [![](https://img.shields.io/github/downloads/ben-z/free-sidecar/total)](https://github.com/ben-z/free-sidecar/releases)
-[![](https://img.shields.io/badge/macOS->=10.15%20Catalina-brightgreen)](#)
+[![](https://img.shields.io/badge/macOS-10.15.*%20Catalina-brightgreen)](#)
 [![](https://img.shields.io/badge/iPadOS->=13-brightgreen)](#)
 
-Unlocks [Sidecar](https://support.apple.com/en-ca/HT210380) for older, unsupported iPads and Macs (supports all iPads running iPadOS and Macs running macOS Catalina or newer).
+Unlocks [Sidecar](https://support.apple.com/en-ca/HT210380) for older, unsupported iPads and Macs (supports all iPads running iPadOS and Macs running macOS Catalina).
 
 [Download the lastest version](https://github.com/ben-z/free-sidecar/releases/latest/download/free-sidecar.zip)
 
 **Full list of supported iPads (running iPadOS):** iPad Air 2, iPad Air (3rd generation), iPad (5th generation), iPad (6th generation), iPad (7th generation), iPad Mini 4, iPad Mini (5th generation), iPad Pro 9.7-inch, iPad Pro 10.5-inch, iPad Pro 11-inch, iPad Pro 12.9-inch (1st generation), iPad Pro 12.9-inch (2nd generation), iPad Pro 12.9-inch (3rd generation)
 
-**List of supported Macs (running macOS Catalina or newer):** iMac: Late 2012 or newer, iMac Pro, Mac Pro: Late 2013 or newer, Mac Mini: Late 2012 or newer, MacBook: Early 2015 or newer, MacBook Air: Mid 2012 or newer, MacBook Pro: Mid 2012 or newer
+**List of supported Macs (running macOS Catalina):** iMac: Late 2012 or newer, iMac Pro, Mac Pro: Late 2013 or newer, Mac Mini: Late 2012 or newer, MacBook: Early 2015 or newer, MacBook Air: Mid 2012 or newer, MacBook Pro: Mid 2012 or newer
 
 ### Notes
 1. Apple uses a simple "blacklist" on macOS to disable iPadOS 13/macOS Catalina devices from using Sidecar. To work around this, we simply need to edit the blacklist in `/System/Library/PrivateFrameworks/SidecarCore.framework/Versions/A/SidecarCore` (can be done with any hex editor of your choice).

--- a/free-sidecar.xcodeproj/project.pbxproj
+++ b/free-sidecar.xcodeproj/project.pbxproj
@@ -440,6 +440,7 @@
 				CODE_SIGN_ENTITLEMENTS = "free-sidecar/free_sidecar.entitlements";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 4;
 				DEVELOPMENT_ASSET_PATHS = "\"free-sidecar/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = "free-sidecar/Info.plist";
@@ -448,6 +449,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.15;
+				MARKETING_VERSION = 1.2.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "benz.free-sidecar";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
@@ -461,6 +463,7 @@
 				CODE_SIGN_ENTITLEMENTS = "free-sidecar/free_sidecar.entitlements";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 4;
 				DEVELOPMENT_ASSET_PATHS = "\"free-sidecar/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = "free-sidecar/Info.plist";
@@ -469,6 +472,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.15;
+				MARKETING_VERSION = 1.2.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "benz.free-sidecar";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;

--- a/free-sidecar/ContentView.swift
+++ b/free-sidecar/ContentView.swift
@@ -139,7 +139,7 @@ struct ContentView: View {
                         .padding(.trailing, 20)
                 }.padding()
                 VStack {
-                    Text("8. Sign the patched SidecarCore (in Terminal):")
+                    Text("8. Sign the patched SidecarCore (in Terminal) (For macOS Catalina 10.15.4+ users, please refer the README):")
                     TextField("", text: $sign)
                         .font(.system(size: 10, design: .monospaced))
                         .padding(.leading, 20)

--- a/free-sidecar/ContentView.swift
+++ b/free-sidecar/ContentView.swift
@@ -139,7 +139,7 @@ struct ContentView: View {
                         .padding(.trailing, 20)
                 }.padding()
                 VStack {
-                    Text("8. Sign the patched SidecarCore (in Terminal) (For macOS Catalina 10.15.4+ users, please refer the README):")
+                    Text("8. Sign the patched SidecarCore (in Terminal) (For macOS Catalina 10.15.4+ users, please refer the README for special instructions):")
                     TextField("", text: $sign)
                         .font(.system(size: 10, design: .monospaced))
                         .padding(.leading, 20)

--- a/free-sidecar/ContentView.swift
+++ b/free-sidecar/ContentView.swift
@@ -139,7 +139,7 @@ struct ContentView: View {
                         .padding(.trailing, 20)
                 }.padding()
                 VStack {
-                    Text("8. Sign the patched SidecarCore (in Terminal) (For macOS Catalina 10.15.4+ users, please refer the README for special instructions):")
+                    Text("8. Sign the patched SidecarCore (in Terminal) (If you are on macOS Catalina 10.15.4+, please refer to step 8 of the README for special instructions):")
                     TextField("", text: $sign)
                         .font(.system(size: 10, design: .monospaced))
                         .padding(.leading, 20)

--- a/free-sidecar/Info.plist
+++ b/free-sidecar/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.2</string>
+	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>3</string>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
 	<key>NSHumanReadableCopyright</key>


### PR DESCRIPTION
**The fix**
Copy the "SidecarCore.framework" folder from an older mac running Catalina.
Then run the patch.

**Good to know:**
You can't mount the filesystem the old way, new way found here: https://itectec.com/askdifferent/macos-can-i-mount-the-root-system-filesystem-as-writable-in-big-sur/

I used the same model MacBook for the copy, I'm not sure if it works with all copies.